### PR TITLE
fix(WithdrawalQueue): remove `head` increment

### DIFF
--- a/contracts/libs/WithdrawalQueue.sol
+++ b/contracts/libs/WithdrawalQueue.sol
@@ -55,7 +55,6 @@ library WithdrawalQueueLib {
             if (withdrawal.epoch > currentEpoch) return (amount, newHead);
             amount += withdrawal.amount;
         }
-        newHead++;
     }
 
     function pending(WithdrawalQueue storage self, uint256 currentEpoch) internal view returns (uint256 amount) {


### PR DESCRIPTION
## Motivation

Fix bug in `withdrawable`, which incremented the `head` again when all withdrawals had been processed.

Caught in https://github.com/maticnetwork/v3-contracts/commit/f442be70f50194ba1a5e3609ac08b2d120b203bb w/ fuzzing.

### Counter-example

A tail with 1 withdrawal for the `currentEpoch`, `head` 0.
The function would return `newHead` 2 instead of 1.

## Solution

Remove the increment.