### PR TITLE
fix(ChildValidatorSet): set validator inactive when stake `0`

### DIFF
--- a/contracts/child/ChildValidatorSet.sol
+++ b/contracts/child/ChildValidatorSet.sol
@@ -167,7 +167,7 @@ contract ChildValidatorSet is System, Owned, ReentrancyGuardUpgradeable, IChildV
         rewardModifiers[msg.sender] += amountInt;
         _queue.insert(msg.sender, amountInt * -1, 0);
         if (amountAfterUnstake == 0) {
-            getValidator(msg.sender).active = false;
+            _validators.get(msg.sender).active = false;
         }
         _registerWithdrawal(msg.sender, amount);
         emit Unstaked(msg.sender, amount);


### PR DESCRIPTION
## Motivation

Fix a bug in `ChildValidatorSet`, which did not set the validator inactive when they had unstaked everything.

## Solution

The `getValidator` function copies the validator in memory before returning it, but we need a storage reference to change `active`.

Reference storage directly with the `get` function instead of using `getValidator`.