### PR TITLE
build(ci): set fuzz runs to 10000

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Get node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "16.x"
-      - run: npm install
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
+      - name: Install Node modules
+        uses: actions/setup-node@v1
+        with:
+          node-version: "16.x"
+      - run: npm install
       - name: Run tests
-        run: forge test -vvv
+        run: FOUNDRY_PROFILE=intense forge test -vvv --no-match-contract=ValidatorStorage && forge test -vvv match-contract=ValidatorStorage
   gas_report:
     runs-on: ubuntu-latest
     steps:

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,10 @@ out = 'out'
 cache_path  = 'forge-cache'
 verbosity = 2
 # comment out if you notice any weird behavior
-#sparse_mode = true
+# sparse_mode = true
+
+# do not use for computationally expensive tests
+[profile.intense.fuzz]
+runs = 10000
 
 # See more config options https://book.getfoundry.sh/reference/config.html


### PR DESCRIPTION
## Motivation

The current 256 fuzz runs is not enough.

## Solution

Create a new Foundry profile `intense` with 10k fuzz runs to use in CI.

`ValidatorStorage` tests will be ran with 256 fuzz runs for now, because they are computationally expensive.