### PR TITLE
fix: correct a mistake in 8fa31ac

### DIFF
--- a/contracts/libs/WithdrawalQueue.sol
+++ b/contracts/libs/WithdrawalQueue.sol
@@ -63,6 +63,7 @@ library WithdrawalQueueLib {
             Withdrawal memory withdrawal = self.withdrawals[i];
             if (withdrawal.epoch <= currentEpoch) break;
             amount += withdrawal.amount;
+            if (i == 0) break;
         }
     }
 }


### PR DESCRIPTION
## Motivation

I mixed up what's `head` and what's `tail` in 8fa31ac.

The fuzzer caught it.

## Solution

Revert the change.