### PR TITLE
test: cover remaining branch in `WithdrawalQueue`

### DIFF
--- a/test/forge/libs/WithdrawalQueue.t.sol
+++ b/test/forge/libs/WithdrawalQueue.t.sol
@@ -135,6 +135,13 @@ contract WithdrawalQueue_MultipleState is MultipleState {
 
         assertEq(withdrawalQueueLibUser.pending(currentEpoch), expectedAmount);
     }
+
+    function testPending_HeadZero() public {
+        withdrawalQueueLibUser.append(1 ether, 2);
+
+        // should break and not underflow
+        assertEq(withdrawalQueueLibUser.pending(1), 1 ether);
+    }
 }
 
 /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

This branch was not covered unless the `intense` profile was used.

## Solution

Add a test.